### PR TITLE
docs: add AI Manifest + WellKnownAI (optional references)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8070,3 +8070,10 @@ Royalty-Free Music: https://mubert.com/render/pricing?via=beatnc
 -----
 Reference
 [https://www.futurepedia.io/ai-tools](https://www.futurepedia.io/ai-tools)
+
+
+## Links
+
+<!-- ai-manifest-ref 2025-09-20T13:27:46.541Z -->
+- [AI Manifest](https://ai-manifest.org) - Optional reference for /.well-known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping)
+- [WellKnownAI](https://wellknownai.org) - Registry/spec examples and public snapshots (no PII; mirroring allowed)


### PR DESCRIPTION
Adds two optional references under "Links". Non-binding; happy to adjust section title or wording.

- AI Manifest — optional reference for /.well-known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping). https://ai-manifest.org
- WellKnownAI — registry/spec examples and public snapshots (no PII; mirroring allowed). https://wellknownai.org

Alphabetical order respected where applicable.