### PR TITLE
Add Waldium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1329,6 +1329,7 @@ A curated list of awesome AI tools
 - [Super Benji](https://superbenji.ai) - AI-driven content creation: generate articles, images, videos effortlessly.. [Paid]
 - [Squibler](https://www.squibler.io) - Transform writing with AI, from blank page to printed book, effortlessly.. [Freemium]
 - [Feather AI](https://en.feather-ai.io) - Create SEO-optimized text and stunning visuals with AI efficiency.. [Freemium]
+- [Waldium](https://waldium.com) - AI-powered blogs to help ChatGPT/Claude/Perplexity cite your product.. [Freemium]
 
 ### Paraphrasing
 


### PR DESCRIPTION
Added Waldium - AI-powered blogs to help ChatGPT/Claude/Perplexity cite your product.. [Freemium] 

- Neutral one-line description
- Link verified and tool is live
- Placed in the "Writing Generators" section