### PR TITLE
Add BurnRate - AI coding cost analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -6924,6 +6924,7 @@ Royalty-Free Music: https://mubert.com/render/pricing?via=beatnc
 - [Dryrun Security](https://www.dryrun.security) - AI-powered security context for seamless code reviews. [Contact for Pricing]
 - [Aspen.io](https://getaspen.io) - AI-enhanced API testing and code generation, tailored for Apple OS.. [Free]
 - [WFGY ProblemMap](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) - MIT-licensed checklist of 16 common RAG / LLM pipeline failure modes, used as a practical debugging guide.. [Free]
+- [BurnRate](https://getburnrate.io) - AI coding cost analytics CLI that tracks usage and costs across Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, and Codex with real-time dashboard and optimization rules.. [Free]
 
 ### Low-code/no-code
 


### PR DESCRIPTION
[BurnRate](https://getburnrate.io) is a local-first CLI tool that tracks AI coding tool usage and costs across 7 providers: Claude Code, Cursor, GitHub Copilot, Windsurf, Aider, Cline, and OpenAI Codex.

- Real-time cost analytics dashboard
- 46 optimization rules to reduce spending
- Rate limit monitoring and team budgets
- Written in Go, single binary

GitHub: https://github.com/burnrate-dev/burnrate