### PR TITLE
Add GEOScore to SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4947,6 +4947,7 @@ Royalty-Free Music: https://mubert.com/render/pricing?via=beatnc
 - [Limecube](https://www.limecube.co) - Unleash AI-powered, intuitive web design with SEO optimization and no coding needed.. [Free Trial]
 - [Gizzmo](https://gizzmo.ai) - Gizzmo WP plugin creates Amazon affiliate articles in just two clicks.. [Free Trial]
 - [Machined](https://machined.ai) - Create researched, cited and interlinked content on any topic.. [Free Trial]
+- [GEOScore](https://geoscoreai.com) - AI search visibility scanner that checks how websites perform in AI search engines (ChatGPT, Perplexity, Gemini). Free scan with 11 technical checks.. [Freemium]
 - [Keywords Everwhere](https://keywordseverywhere.com) - Unlock SEO insights across platforms with real-time keyword data.. [Paid]
 - [Copyleaks](https://copyleaks.com) - Detects plagiarism, ensures content authenticity, supports multiple formats.. [Freemium]
 - [Eloise](https://Eloise.ai) - Unlock multilingual, SEO-optimized content creation with AI efficiency.. [Active deal]


### PR DESCRIPTION
## What's added?

Added [GEOScore](https://geoscoreai.com) to the SEO section — an AI search visibility scanner that checks how websites perform in AI search engines (ChatGPT, Perplexity, Gemini). It offers a free scan with 11 technical checks.

## Why?

GEOScore is an AI-powered SEO tool focused on a new dimension of search: AI search engines. It complements the existing SEO tools in this list by analyzing visibility in ChatGPT, Perplexity, and Gemini rather than traditional search engines.