### PR TITLE
Add Pilio Watermark Remover to Image Editing

### DIFF
--- a/2025/Image.md
+++ b/2025/Image.md
@@ -502,6 +502,7 @@
 - [Venngage](https://venngage.com) - Create personalized, visually stunning designs effortlessly online.. [Free]
 - [Vectorizer.ai](https://vectorizer.ai) - Transform raster images to high-quality vectors effortlessly with AI precision.. [Paid]
 - [Photo Editor AI](https://photoeditor.ai) - Remove unwanted objects, people, blemishes, or text from their images in seconds.. [Free]
+- [Pilio Watermark Remover](https://pilio.ai/zh/remove-watermark) - Remove watermarks from images and PDFs with AI; includes [Image Watermark Remover](https://pilio.ai/zh/image-watermark-remover), [Gemini Watermark Remover](https://pilio.ai/zh/gemini-watermark-remover), and an open-source [GitHub](https://github.com/GargantuaX/gemini-watermark-remover) implementation.. [Freemium]
 - [Image Candy](https://imgcandy.com) - Versatile online image editing, conversion, and compression tool.. [Free]
 - [Paintit](https://paintit.ai) - Revolutionize your space with AI-driven interior design visualization.. [Free]
 - [Final Touch](https://final-tou.ch) - Revolutionize product visuals with AI-driven scene generation and no-code editing.. [Free]

--- a/2025/README.md
+++ b/2025/README.md
@@ -4727,6 +4727,7 @@ A curated list of awesome AI tools
 - [CopyMonkey](https://copymonkey.ai) - Optimize Amazon listings with AI-driven, keyword-rich content generation.. [Free Trial]
 - [eCommerce Prompt Generator](https://www.ecommerceprompts.com) - Revolutionize eCommerce content creation with tailored, engaging copy instantly.. [Free]
 - [Photo Editor AI](https://photoeditor.ai) - Remove unwanted objects, people, blemishes, or text from their images in seconds.. [Free]
+- [Pilio Watermark Remover](https://pilio.ai/zh/remove-watermark) - Remove watermarks from images and PDFs with AI; includes [Image Watermark Remover](https://pilio.ai/zh/image-watermark-remover), [Gemini Watermark Remover](https://pilio.ai/zh/gemini-watermark-remover), and an open-source [GitHub](https://github.com/GargantuaX/gemini-watermark-remover) implementation.. [Freemium]
 - [Image Candy](https://imgcandy.com) - Versatile online image editing, conversion, and compression tool.. [Free]
 - [Final Touch](https://final-tou.ch) - Revolutionize product visuals with AI-driven scene generation and no-code editing.. [Free]
 - [One AI](https://www.oneai.com) - Boost website engagement and sales with adaptive AI-driven interactions.. [Freemium]

--- a/Image.md
+++ b/Image.md
@@ -503,6 +503,7 @@
 - [Venngage](https://venngage.com) - Create personalized, visually stunning designs effortlessly online.. [Free]
 - [Vectorizer.ai](https://vectorizer.ai) - Transform raster images to high-quality vectors effortlessly with AI precision.. [Paid]
 - [Photo Editor AI](https://photoeditor.ai) - Remove unwanted objects, people, blemishes, or text from their images in seconds.. [Free]
+- [Pilio Watermark Remover](https://pilio.ai/zh/remove-watermark) - Remove watermarks from images and PDFs with AI; includes [Image Watermark Remover](https://pilio.ai/zh/image-watermark-remover), [Gemini Watermark Remover](https://pilio.ai/zh/gemini-watermark-remover), and an open-source [GitHub](https://github.com/GargantuaX/gemini-watermark-remover) implementation.. [Freemium]
 - [Image Candy](https://imgcandy.com) - Versatile online image editing, conversion, and compression tool.. [Free]
 - [Paintit](https://paintit.ai) - Revolutionize your space with AI-driven interior design visualization.. [Free]
 - [Final Touch](https://final-tou.ch) - Revolutionize product visuals with AI-driven scene generation and no-code editing.. [Free]

--- a/README.md
+++ b/README.md
@@ -4753,6 +4753,7 @@ Royalty-Free Music: https://mubert.com/render/pricing?via=beatnc
 - [CopyMonkey](https://copymonkey.ai) - Optimize Amazon listings with AI-driven, keyword-rich content generation.. [Free Trial]
 - [eCommerce Prompt Generator](https://www.ecommerceprompts.com) - Revolutionize eCommerce content creation with tailored, engaging copy instantly.. [Free]
 - [Photo Editor AI](https://photoeditor.ai) - Remove unwanted objects, people, blemishes, or text from their images in seconds.. [Free]
+- [Pilio Watermark Remover](https://pilio.ai/zh/remove-watermark) - Remove watermarks from images and PDFs with AI; includes [Image Watermark Remover](https://pilio.ai/zh/image-watermark-remover), [Gemini Watermark Remover](https://pilio.ai/zh/gemini-watermark-remover), and an open-source [GitHub](https://github.com/GargantuaX/gemini-watermark-remover) implementation.. [Freemium]
 - [Image Candy](https://imgcandy.com) - Versatile online image editing, conversion, and compression tool.. [Free]
 - [Final Touch](https://final-tou.ch) - Revolutionize product visuals with AI-driven scene generation and no-code editing.. [Free]
 - [One AI](https://www.oneai.com) - Boost website engagement and sales with adaptive AI-driven interactions.. [Freemium]


### PR DESCRIPTION
This PR adds `Pilio Watermark Remover` to the `Image Editing` section in:
- `README.md`
- `Image.md`
- `2025/README.md`
- `2025/Image.md`

Included links:
- Main tool: https://pilio.ai/zh/remove-watermark
- Image Watermark Remover: https://pilio.ai/zh/image-watermark-remover
- Gemini Watermark Remover: https://pilio.ai/zh/gemini-watermark-remover
- Open-source GitHub: https://github.com/GargantuaX/gemini-watermark-remover

Why it fits this section:
- removes watermarks from images and PDFs
- includes a dedicated Gemini watermark remover
- also provides an open-source browser-based implementation
