### PR TITLE
Add OpenClaw - self-hosted AI agent runtime for non-technical users

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A curated list of awesome AI tools
 ## Productivity Tools
 
 ### Personal Assistant
+- [OpenClaw](https://openclawapp.netlify.app) - Self-hosted AI agent runtime for non-technical entrepreneurs. Run AI agents 24/7 for £2-15/month instead of £200+/month. Control via Telegram/phone. No coding required. [Paid]
 - [Undetectable ChatGPT Chrome Extension](https://chromewebstore.google.com) - Invisible ChatGPT integration for seamless, discreet browsing.. [Free]
 - [Monica](https://monica.im) - Personal Al assistant for effortless chatting and copywriting.. [Freemium]
 - [You](https://you.com) - Transforms searches into personalized, private experiences with AI-driven results.. [Freemium]


### PR DESCRIPTION
Adding OpenClaw to the Personal Assistant section.

OpenClaw is a self-hosted AI agent runtime designed for non-technical entrepreneurs:
- Run AI agents 24/7 on your own machine
- Pay £2-15/month in API costs instead of £200+/month for SaaS
- Control agents from your phone via Telegram
- No coding required — step-by-step course available
- Based on [openclaw/openclaw](https://github.com/openclaw/openclaw) (328k GitHub stars)