### PR TITLE
Add AuditZap to SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4933,6 +4933,7 @@ Royalty-Free Music: https://mubert.com/render/pricing?via=beatnc
 
 ### SEO
 
+- [AuditZap](https://auditzap.io) - AI-powered website audit tool that runs 24 checks and generates code-level fix instructions ranked by revenue impact.. [Freemium]
 - [Seo Juice](https://seojuice.io) - Automate SEO internal linking and enhance rankings effortlessly.. [Free Trial]
 - [MarketMuse](https://www.marketmuse.com) - Revolutionize content strategy with AI-driven research, planning, and optimization.. [Freemium]
 - [Surfer](https://surferseo.com) - Surfer is a growth management platform that empowers businesses to enhance their organic traffic and search engine rankings.. [Paid]


### PR DESCRIPTION
Adding [AuditZap](https://auditzap.io/) to the SEO section under Business.

AI-powered website audit tool that runs 24 checks and generates code-level fix instructions ranked by revenue impact. Freemium model.

- Live at https://auditzap.io

Disclosure: I am the creator of AuditZap.