### PR TITLE
Add GetLLMPricing to pricing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ A curated list of awesome AI tools
 ### Research Assistant
 
 - [Price Per Token](https://pricepertoken.com) - Compare LLM API pricing across 300+ models from OpenAI, Anthropic, Google, and 30+ providers. [Free]
+- [GetLLMPricing](https://6a9df8d0.getllmpricing.pages.dev/openai-pricing-calculator) - OpenAI pricing calculator and LLM pricing comparison entry point with canonical, sitemap, and template landing pages. [Free]
 - [Gnomi App](https://www.gnomi.com) - Unlock global perspectives, customize content, and engage with a diverse community in real-time.. [Free]
 - [Consensus](https://consensus.app) - Unlock expert knowledge: AI-powered, ad-free research from 200M+ scientific papers.. [Freemium]
 - [BGPT MCP](https://bgpt.pro) - Search scientific papers built from full-text experimental data via hosted MCP server. 50 free searches, no API key needed. [Free]


### PR DESCRIPTION
Add GetLLMPricing as an OpenAI pricing calculator and LLM pricing comparison tool.