### PR TITLE
Add AI Hotlist to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6483,6 +6483,7 @@ Royalty-Free Music: https://mubert.com/render/pricing?via=beatnc
 
 ### AI Agents
 
+- [AI Hotlist](https://aihot.bt199.com/) - Chinese AI tools, models, agents and AI news hotlist, refreshed every 6 hours. [Free]
 - [Rapport](https://www.rapport.cloud) - Create emotionally intelligent, multilingual, customizable AI characters.. [Free Trial]
 - [AutoGPT](https://github.com) - An experimental open-source attempt to make GPT-4 fully autonomous.. [Free]
 - [AgentVerse](https://agentverse.ai) - Explore, create, manage AI agents effortlessly; enhance efficiency, cut costs.. [Contact for Pricing]


### PR DESCRIPTION
## Summary
- Adds AI Hotlist to the AI Agents section
- AI Hotlist tracks Chinese AI tools, models, agents, and AI news, refreshed every 6 hours

## Why it fits
The list includes AI agent and AI discovery resources. AI Hotlist is a focused directory/hotlist that helps users discover current Chinese AI tools and agent-related resources.

## Checks
- Link verified reachable: https://aihot.bt199.com/
- Added one relevant resource only
- Preserved the existing list style