### PR TITLE
Add AdDogs to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3754,6 +3754,7 @@ Royalty-Free Music: https://mubert.com/render/pricing?via=beatnc
 - [Ad Intel](https://usemadmen.ai) - Unlock competitor ad insights, optimize strategy, boost ROAS.. [Freemium]
 - [Adsby](https://adsby.co) - Maximize ad impact with AI-driven creation, optimization, and keyword suggestions.. [Free Trial]
 - [LeadFox](https://getleadfox.com) - Auto-reply to LinkedIn comments & capture leads while you sleep.. [Paid]
+- [AdDogs](https://www.addogs.ai) - AI ad creative generator that clones any winning ad design, swaps in your product photo, and applies your brand colors and logo in seconds.. [Freemium]
 
 ### Finance
 


### PR DESCRIPTION
Adds [AdDogs](https://www.addogs.ai) to the Marketing section.

**What it is:** AI ad creative generator. Pick any winning ad design, upload your product photo, and the AI recreates the ad with your product — preserving the original layout, style, and composition. Brand colors and logo are extracted automatically.

**Why Marketing:** Sits naturally alongside Adcreative.ai, Ad Intel, and Adsby — generative ad creative tools — but specializes in cloning the layout/composition of an existing winning ad rather than generating from scratch. Exports in 14 aspect ratios for Instagram, TikTok, Facebook, and Google.

Real, public, working product. Free tier available; paid plans from $12/mo (marked as Freemium to match the convention used for Copy.ai, Writesonic, etc.).

Happy to adjust placement or wording. Thanks for maintaining this list.