### PR TITLE
Add Tudo to productivity tools

### DIFF
--- a/Productivity.md
+++ b/Productivity.md
@@ -10,6 +10,7 @@
   - [Search Engine](#search-engine)
 
 ### Personal Assistant
+- [Tudo](https://blynkai.app/tudo/) - AI task manager for iPhone that turns voice notes, screenshots, and text into organized tasks and plans.. [Free]
 - [Undetectable ChatGPT Chrome Extension](https://chromewebstore.google.com) - Invisible ChatGPT integration for seamless, discreet browsing.. [Free]
 - [Monica](https://monica.im) - Personal Al assistant for effortless chatting and copywriting.. [Freemium]
 - [You](https://you.com) - Transforms searches into personalized, private experiences with AI-driven results.. [Freemium]


### PR DESCRIPTION
Adds Tudo to Productivity.md under Personal Assistant using the existing list format.

Related issue: #157